### PR TITLE
Temporary put $this->model into a new variable

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -259,6 +259,7 @@ abstract class Repository
      */
     protected function getCreatedAtColumn()
     {
-        return ($this->model::CREATED_AT) ? $this->model::CREATED_AT : 'created_at';
+        $model = $this->model;
+        return ($model::CREATED_AT) ? $model::CREATED_AT : 'created_at';
     }
 }


### PR DESCRIPTION
On PHP 5.6.3, line 263 gives this error: 
```syntax error, unexpected '::' (T_PAAMAYIM_NEKUDOTAYIM)```

However, putting ``$this->model`` into a temp variable before using it to access ``::CREATED_AT`` solves the problem.